### PR TITLE
Replace import_role with include_role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,9 +1,9 @@
 - hosts: localhost
   gather_facts: no
   tasks:
-  - import_role:
+  - include_role:
       name: "uperf-bench"
-    when: uperf.pair > 0
-  - import_role:
+    when: uperf is defined and uperf.pair > 0
+  - include_role:
       name: "fio-bench"
-    when: fio.clients > 0
+    when: fio is defined and fio.clients > 0


### PR DESCRIPTION
include_role should be used in this case for conditional execution
of workloads[1]. If using import_role, the when condition only applies
to each task in the role but not to the import statement[2]. Also, if you
are using import_role, all the variables within the role are available
in this playbook and hence the when condition uses vars from the role
defaults. In the case of include_role, the role is conditionally imported
based on the when statement which is what we want in this case.

Also adding check to see if the workload was defined before continuing more
specific checks into workload parameters. This will prevent undefined var errors
by shortciruting with the and operator

References:
1. https://docs.ansible.com/ansible/latest/modules/include_role_module.html
2. https://docs.ansible.com/ansible/latest/modules/import_role_module.html