### PR TITLE
Updated CI testing structure

### DIFF
--- a/full_test.sh
+++ b/full_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+source tests/common.sh
+
+trap cleanup_operator_resources EXIT
+
+create_operator
+update_operator_image
+#
+# Test all workloads without recreating operator pods
+#
+source tests/test_uperf.sh
+functional_test_uperf
+source tests/test_fio.sh
+functional_test_fio

--- a/test.sh
+++ b/test.sh
@@ -1,60 +1,19 @@
 #!/usr/bin/env bash
 set -xeo pipefail
-function finish {
-  echo "Exiting after cleanup"
-  kubectl delete -f deploy/operator.yaml
-  kubectl delete -f deploy/crds/bench_v1alpha1_bench_crd.yaml
-  kubectl delete -f deploy/service_account.yaml
-  kubectl delete -f deploy/role_binding.yaml
-  kubectl delete -f deploy/role.yaml
-}
 
-function wait_clean {
-  for i in {1..30}; do
-    if [ `kubectl get pods|wc -l` -ge 2 ]; then
-      sleep 5
-    else
-      break
-    fi
-  done
-}
+source tests/common.sh
 
-trap finish EXIT
+trap cleanup_resources EXIT
 
-kubectl apply -f deploy/role.yaml
-kubectl apply -f deploy/role_binding.yaml
-kubectl apply -f deploy/service_account.yaml
-kubectl apply -f deploy/crds/bench_v1alpha1_bench_crd.yaml
-
-operator-sdk build quay.io/rht_perf_ci/benchmark-operator
-
-docker push quay.io/rht_perf_ci/benchmark-operator
-
-sed -i 's|          image: *|          image: quay.io/rht_perf_ci/benchmark-operator:latest # |' deploy/operator.yaml
-
+operator_requirements
+update_operator_image
 #
-# Iterate through workloads individually
+# Run functional test for workloads
 #
 # Test UPerf
-kubectl apply -f deploy/operator.yaml
 /bin/bash tests/test_uperf.sh
-kubectl delete -f tests/test_crs/valid_uperf.yaml
-kubectl delete -f deploy/operator.yaml
-
 wait_clean
-
 #
 # Test FIO
-kubectl apply -f deploy/operator.yaml
 /bin/bash tests/test_fio.sh
-kubectl delete -f tests/test_crs/valid_fio.yaml
-kubectl delete -f deploy/operator.yaml
-
 wait_clean
-
-#
-# Test all workloads
-#
-kubectl apply -f deploy/operator.yaml
-/bin/bash tests/test_uperf.sh
-/bin/bash tests/test_fio.sh

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,6 +1,55 @@
 #!/usr/bin/env bash
 
-function check_status() {
+function apply_operator {
+  kubectl apply -f deploy/operator.yaml
+}
+
+function delete_operator {
+  kubectl delete -f deploy/operator.yaml
+}
+
+function operator_requirements {
+  kubectl apply -f deploy/role.yaml
+  kubectl apply -f deploy/role_binding.yaml
+  kubectl apply -f deploy/service_account.yaml
+  kubectl apply -f deploy/crds/bench_v1alpha1_bench_crd.yaml
+}
+
+function create_operator {
+  operator_requirements
+  apply_operator
+}
+
+function cleanup_resources {
+  echo "Exiting after cleanup of resources"
+  kubectl delete -f deploy/crds/bench_v1alpha1_bench_crd.yaml
+  kubectl delete -f deploy/service_account.yaml
+  kubectl delete -f deploy/role_binding.yaml
+  kubectl delete -f deploy/role.yaml
+}
+
+function cleanup_operator_resources {
+  delete_operator
+  cleanup_resources
+}
+
+function update_operator_image {
+  operator-sdk build quay.io/rht_perf_ci/benchmark-operator
+  docker push quay.io/rht_perf_ci/benchmark-operator
+  sed -i 's|          image: *|          image: quay.io/rht_perf_ci/benchmark-operator:latest # |' deploy/operator.yaml
+}
+
+function wait_clean {
+  for i in {1..30}; do
+    if [ `kubectl get pods | grep bench | wc -l` -ge 2 ]; then
+      sleep 5
+    else
+      break
+    fi
+  done
+}
+
+function check_pods() {
   for i in {1..10}; do
     if [ `kubectl get pods | grep bench | wc -l` -gt $1 ]; then
       break

--- a/tests/test_fio.sh
+++ b/tests/test_fio.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
-# Instead of applying the cr, we should create different crs and
-kubectl apply -f tests/test_crs/valid_fio.yaml
-sleep 30
-fio_client_pod=$(kubectl get pods -l app=fio-bench-server -o name | cut -d/ -f2)
-sleep 150
-# ensuring the run has actually happened
-kubectl logs "$fio_client_pod" | grep "Run status"
+source tests/common.sh
+
+function finish {
+  echo "Cleaning up Fio"
+  kubectl delete -f tests/test_crs/valid_fio.yaml
+  delete_operator
+}
+
+trap finish EXIT
+
+function functional_test_uperf {
+  apply_operator
+  kubectl apply -f tests/test_crs/valid_fio.yaml
+  sleep 30
+  fio_pod=$(kubectl get pods -l app=fio-bench-server -o name | cut -d/ -f2)
+  kubectl wait --for=condition=Initialized "pods/$fio_pod" --timeout=200s
+  kubectl wait --for=condition=Ready "pods/$fio_pod" --timeout=200s
+  sleep 30
+  # ensuring the run has actually happened
+  kubectl logs "$fio_pod" | grep "Run status"
+}
+
+functional_test_uperf

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -3,15 +3,28 @@ set -xeo pipefail
 
 source tests/common.sh
 
-# Instead of applying the cr, we should create different crs and
-kubectl apply -f tests/test_crs/valid_uperf.yaml
-check_status 2
-uperf_client_pod=$(kubectl get pods -l app=uperf-bench-client -o name | cut -d/ -f2)
+function finish {
+  echo "Cleaning up Uperf"
+  kubectl delete -f tests/test_crs/valid_uperf.yaml
+  delete_operator
+}
 
-check_log $uperf_client_pod "Success"
-#timeout 500 kubectl logs -f $uperf_client_pod
+trap finish EXIT
 
-kubectl get pods -l name=benchmark-operator -o name | cut -d/ -f2 | xargs -I{} kubectl exec {} -- cat /tmp/current_run
+function functional_test_uperf {
+  apply_operator
+  kubectl apply -f tests/test_crs/valid_uperf.yaml
+  check_pods 2
+  uperf_client_pod=$(kubectl get pods -l app=uperf-bench-client -o name | cut -d/ -f2)
 
-# ensuring that uperf actually ran and we can access metrics
-kubectl logs "$uperf_client_pod" | grep Success
+  kubectl wait --for=condition=Initialized "pods/$uperf_client_pod" --timeout=200s
+  kubectl wait --for=condition=Ready "pods/$uperf_client_pod" --timeout=45s
+  #check_log $uperf_client_pod "Success"
+  # This is for the operator playbook to finish running
+  sleep 30
+  kubectl get pods -l name=benchmark-operator -o name | cut -d/ -f2 | xargs -I{} kubectl exec {} -- cat /tmp/current_run
+
+  # ensuring that uperf actually ran and we can access metrics
+  kubectl logs "$uperf_client_pod" | grep Success
+}
+functional_test_uperf


### PR DESCRIPTION
1. Divided test.sh into two:

- test.sh - Functional testing for each workload
- full_test.sh - E2E integration testing of sort where operator will not be redeployed

2. Using kubectl wait mechanism instead of using sleep